### PR TITLE
Docs: Add PATENTS.md with initiator's patent grant

### DIFF
--- a/PATENTS.md
+++ b/PATENTS.md
@@ -1,0 +1,105 @@
+# Patent Information for the RABS Project
+
+---
+**Important Note on Our Legal Documents**
+
+Please be aware that the legal texts provided in this project,
+including but not limited to the patent grant statement in this
+`PATENTS.md` file and other policy documents, have been drafted by
+the project initiator (frostmnh) to the best of their current
+abilities. This process included the use of AI-assisted resources
+for drafting and refinement, and was undertaken without direct
+legal counsel. Consequently, these documents have not yet undergone
+a formal review by legal professionals.
+
+Our goal is to foster an open, fair, and collaborative environment
+for the RABS project. We have made every effort to ensure these
+texts accurately reflect our intentions regarding open source
+licensing, patent grants, and community guidelines. However, users
+and contributors should use this information with the understanding
+of its current limitations.
+
+The project initiator plans to seek professional legal review and
+update these documents as the project matures and resources become
+available. We sincerely appreciate your understanding, participation,
+and any feedback you may have.
+---
+
+## General Statement on Patents
+
+The RABS project is distributed under the MIT License. The MIT
+License is a permissive free software license. It is important for
+users and contributors to understand that the MIT License itself
+does not include an express grant of patent rights from all
+contributors or the project initiator, beyond what may be implied
+by law or through separate, explicit declarations.
+
+Users and contributors should be aware of potential patent risks
+associated with software development and use. Contributors are
+expected to make their contributions in good faith and, to the best
+of their knowledge, ensure their contributions do not infringe
+existing third-party patents. Users of this software are
+responsible for assessing any patent-related risks associated
+with their use, modification, or distribution of the RABS project
+or any derivative works.
+
+## Patent Grant from [林定翔] (frostmnh) (Project Initiator)
+
+[林定翔] (frostmnh), in their capacity as the initiator and a
+principal contributor to the RABS project (hereinafter "the Project
+Initiator"), hereby grants to each recipient and user of the RABS
+project (hereinafter "Licensee") a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable patent license
+to make, have made, use, offer to sell, sell, import, and
+otherwise transfer the RABS project software.
+
+This license applies only to those patent claims, licensable by the
+Project Initiator, that are necessarily infringed by the Project
+Initiator's Contribution(s) alone or by combination of the Project
+Initiator's Contribution(s) with the RABS project to which such
+Contribution(s) was submitted, as such Contribution(s) are
+incorporated in the RABS project as of the date of such
+Contribution(s).
+
+This patent grant is provided to encourage the widest possible use,
+modification, and distribution of the RABS project under the terms
+of the MIT License. This patent grant is provided "AS IS", WITHOUT
+WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT.
+
+This patent grant is unconditional and shall not be terminated,
+suspended, or diminished due to any patent litigation or assertion
+of patent rights by Licensee or any other entity against the
+Project Initiator or any other party, with respect to any patent
+claims, whether or not such claims are related to the RABS project
+or the Project Initiator's Contribution(s). The intent of this
+grant is to ensure that the patent rights held by the Project
+Initiator in their Contributions to the RABS project do not become
+a barrier to the free use and development of the RABS project.
+
+This patent grant does not extend to any patent claims that would
+be infringed only as a consequence of:
+(a) further modification of the Project Initiator's Contribution(s)
+    by a third party after such Contribution(s) have been
+    incorporated into the RABS project; or
+(b) the combination of the Project Initiator's Contribution(s)
+    with other software, hardware, or technology not provided by
+    the Project Initiator as part of the RABS project, unless such
+    combination itself is a necessary consequence of the Project
+    Initiator's Contribution(s) as provided.
+
+No other rights, express or implied, are granted by the Project
+Initiator with respect to any other patents they may hold that are
+not necessarily infringed by their Contribution(s) to the RABS
+project.
+
+For clarity, this patent grant is separate from and supplemental to
+the copyright license (MIT License) under which the RABS project
+is distributed.
+
+If any provision of this patent grant is held to be unenforceable,
+the remaining provisions shall remain in full force and effect.
+
+Date: [2025-05-23]
+By: [林定翔] (frostmnh)


### PR DESCRIPTION
This commit introduces the PATENTS.md file to the RABS project.

This file serves several important purposes:

1.  It includes an important note regarding the drafting process of legal documents for this project, acknowledging that they were prepared without direct legal counsel at this stage and may utilize AI-assisted tools.
2.  It provides a general statement on patents, clarifying the relationship between the MIT License (under which RABS is distributed) and patent rights, and outlines general expectations for users and contributors regarding patents.
3.  Most importantly, it contains an explicit patent grant from the project initiator, [林定翔] (frostmnh), for their own patented contributions to the RABS project. This grant is intended to be perpetual, worldwide, royalty-free, irrevocable, and unconditional (not subject to patent retaliation clauses).

The addition of this PATENTS.md file aims to:
- Enhance transparency regarding intellectual property.
- Provide users with greater clarity and confidence when using RABS, particularly concerning patents held by the initiator.
- Fulfill the project's commitment to open and responsible development practices.

Users and contributors are encouraged to review this new document.