### PR TITLE
Docs/add brand guidelines

### DIFF
--- a/BRAND_GUIDELINES.md
+++ b/BRAND_GUIDELINES.md
@@ -1,0 +1,122 @@
+# RABS Project - Brand and Trademark Guidelines
+
+Thank you for your interest in the RABS project! We appreciate you wanting
+to share and discuss our work. These guidelines are designed to help you
+understand how you can use the RABS project name and any associated logos or
+trademarks (collectively, "RABS Marks") correctly, while also protecting the
+integrity and identity of the project.
+
+Our goal is to encourage fair and descriptive use of the RABS Marks, while
+preventing uses that could cause confusion or falsely imply an official
+endorsement or affiliation with the RABS project or its initiator(s).
+
+## Our Project Identifiers (RABS Marks)
+
+Currently, the primary RABS Mark is the project name:
+
+*   **RABS** (referring to this Remote AUR Build System project)
+
+(If you create a logo in the future, you would add it here, e.g.,
+"The RABS Logo [image or description]")
+
+## Permitted Uses (What You CAN Do)
+
+We encourage you to:
+
+1.  **Refer to the RABS project by its name:** You are free to use the name
+    "RABS" to accurately describe or refer to our open source project.
+    *   *Example:* "I use RABS to build my AUR packages remotely."
+    *   *Example:* "This tutorial explains how to set up the RABS server."
+
+2.  **State factual, descriptive information about RABS:** You can accurately
+    describe the functionality, features, and purpose of the RABS project.
+    *   *Example:* "RABS is a client-server application designed to offload
+        AUR package compilation to a remote machine."
+
+3.  **Express your opinion or share your experience with RABS:** We welcome
+    you to share your thoughts, whether positive or critical, about the RABS
+    project.
+    *   *Example:* "I find RABS very useful for managing my AUR builds."
+    *   *Example:* "My workflow has improved since I started using RABS."
+    *   *Example:* "I created artwork inspired by RABS's concept."
+
+4.  **Develop and distribute software that is compatible with or works with
+    RABS:** You can create tools, scripts, or plugins that interact with or
+    extend RABS, and accurately state that your software is "for RABS,"
+    "works with RABS," or is "RABS-compatible," if true.
+    *   *Example:* "This is a RABS client GUI I developed."
+    *   *Example:* "My script automates RABS deployment."
+
+5.  **Fair use in academic papers, reviews, articles, and tutorials:** You
+    may use the RABS Marks in publications, reviews, and educational
+    materials, provided the use is fair and not misleading.
+
+6.  **Describe your work as being "similar to" or "inspired by" RABS (for
+    independent projects):** If you are developing your own separate project
+    that shares conceptual similarities with RABS, you can describe it as
+    such, as long as it's clear that your project is distinct and not an
+    official part of RABS or endorsed by us.
+    *   *Example:* "Our new build tool is similar in concept to RABS, but
+        focuses on a different use case."
+
+## Prohibited Uses (What You CANNOT Do Without Permission)
+
+To avoid confusion and protect the project's identity, you **may not** use
+the RABS Marks in the following ways without explicit prior written
+permission from the RABS project initiator, **[林定翔] (frostmnh on GitHub)**:
+
+1.  **Implying Official Endorsement, Sponsorship, or Affiliation:** Do not
+    use the RABS Marks in any way that suggests an official endorsement,
+    sponsorship, partnership, or affiliation with the RABS project or its
+    initiator(s), unless such a relationship officially exists and you have
+    been authorized.
+    *   *Example (Prohibited):* Naming your product "RABS Certified Plugin"
+        or "The Official RABS Guide" without permission.
+    *   *Example (Prohibited):* Using RABS Marks to make your product look
+        like an official RABS offering.
+
+2.  **Confusingly Similar Names or Marks:** Do not use names, logos, or
+    domain names that are confusingly similar to the RABS Marks. This
+    includes misspellings, phonetic equivalents, or translations that could
+    cause users to believe your product or service is an official RABS
+    project or is endorsed by us.
+
+3.  **Incorporating RABS Marks into Your Own Trademarks, Product Names,
+    Service Names, or Company Names:** You may not use or register, in whole
+    or in part, the RABS Marks as part of your own trademarks, product
+    names, service names, domain names, or company names.
+
+4.  **Commercial Use that Implies Endorsement:** While RABS is open source,
+    using RABS Marks in a commercial product or service in a way that
+    implies official endorsement or that your product is an official RABS
+    product requires permission. (Fair descriptive use, e.g., "Our service
+    helps manage RABS deployments," is generally fine, but avoid anything
+    misleading).
+
+5.  **Altering or Modifying RABS Marks:** (Applies more if you have a logo)
+    Do not distort, modify, or alter the RABS Marks.
+
+6.  **Use in a Way That Disparages RABS:** While we welcome constructive
+    criticism, do not use the RABS Marks in a way that is defamatory,
+    libelous, or otherwise disparaging to the RABS project or its
+    community.
+
+## Requesting Permission
+
+If your intended use case falls into the "Prohibited Uses" category, or if
+you are unsure, please contact us to request permission or clarification.
+We are generally open to collaborations and supportive uses, but we need to
+ensure they align with the project's identity and goals.
+
+Please contact **frostmnh via GitHub. You can do this by creating an Issue
+in the RABS project repository, or by checking the contact information on
+the frostmnh GitHub profile.** for any questions regarding these
+guidelines or to request permission for specific uses.
+
+## Reservation of Rights
+
+The RABS project initiator(s) reserve all rights to the RABS Marks. We may
+update these guidelines from time to time. Your continued use of the RABS
+Marks constitutes your acceptance of any such updates.
+
+---

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2025 林定翔 (frostmnh)
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
close #17

This PR introduces the initial version of the RABS Project Brand and Trademark Guidelines.

The guidelines cover:
- Permitted uses of the RABS name.
- Prohibited uses, especially those implying official endorsement.
- Contact information for permission requests.

This helps establish clear rules for how the project's brand should be used.